### PR TITLE
Implementing error and before-render events

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,8 +35,8 @@ var ElectronEjs = function(data, options)
       //Get the file extension
       var extension = path.extname(file);
 
-      fs.access(file, fs.F_OK | fs.R_OK, function(err) {
-        if(err)
+      fs.exists(file, function(exists) {
+        if(!exists)
         {
           self.emit("error", err);
           //File not found
@@ -51,11 +51,12 @@ var ElectronEjs = function(data, options)
           
           var renderTemplate = function()
           {
+
             //Render the full file
-            ejs.renderFile(file, data, options, function(err2, content) {
-              if(err2)
+            ejs.renderFile(file, data, options, function(err, content) {
+              if(err)
               {
-                self.emit("error", err2);
+                self.emit("error", err);
                 //An unexpected error
                 return callback(-9);
               }

--- a/index.js
+++ b/index.js
@@ -16,7 +16,11 @@ var app = electron.app;
 var ElectronEjs = function(data, options)
 {
   var self = this;
-  self.emit("test", "test");
+  if(self.emit === undefined)
+  {
+    throw Error("This initialization is obsolete! Please look documentation for more informations.");
+    return;
+  }
   //Check data and options
   if(typeof data === 'undefined') { var data = {}; }
   if(typeof options === 'undefined') { var options = {}; }


### PR DESCRIPTION
I added events made under EventEmitter, `error` and `before-render`
`before-render` have ability to change file, options and data to be changed relative, then just call renderTemplate to render. If its event not handled, its just render with defaults.

Then I add the options parameter to constructor (real options for EJS).

But, its a little problem here.
I don't know why, but when is class initialized by:

``` js
var ElectronEjs = require("electron-ejs")();
```

the self.emit doesn't work (it's just write the self.emit is not defined).
But when I use a

``` js
var ElectronEjs = require("electron-ejs");
var ejs = new ElectronEjs();
```

All is working nicely.
This commit contains an UTF8 fix too.

What do you thing @jmjuanes ?
