### PR TITLE
FIX. Added url sanitization for paths with spaces in the name

### DIFF
--- a/index.js
+++ b/index.js
@@ -139,6 +139,12 @@ function ParsePath(u)
     pname = pname.substr(1);
   }
 
+
+  //Sanitize URL. Spaces turn into `%20` symbols in the path and
+  //throws a `File Not Found Event`. This fix allows folder paths to have
+  //spaces in the folder name.
+  pname = pname.replace(/\s/g, ' ').replace(/%20/g, ' ');
+
   //Return the path name
   return pname;
 }


### PR DESCRIPTION
There was a problem where my EJS view would not render in electron. Although non-EJS pages would work just fine. Turns out the path to the file had folders with spaces in the directory name. This was enough to throw a `File Not Found` event. 

Added sanitization to the file path to read files with spaces correctly.
