### PR TITLE
Fix obsolete initialization error.

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ npm install electron-ejs
 ```javascript
 //Import dependencies
 var electron = require('electron');
-var electronEjs = require('electron-ejs')();
+var electronEjs = require('electron-ejs');
 
 //Initialize the app
 var app = electron.app;


### PR DESCRIPTION
To override an error that occurs using (in my case) electron 2.0.14 with node 9.11.2

```
A JavaScript error occurred in the main process
Uncaught Exception:
Error: This initialization is obsolete! Please look documentation for more informations.
    at ElectronEjs (/home/choco/Repos/CrystalChocolate/node_modules/electron-ejs/index.js:25:11)
    at Object.<anonymous> (/home/choco/Repos/CrystalChocolate/main.js:7:44)
    at Object.<anonymous> (/home/choco/Repos/CrystalChocolate/main.js:202:3)
    at Module._compile (module.js:642:30)
    at Object.Module._extensions..js (module.js:653:10)
    at Module.load (module.js:561:32)
    at tryModuleLoad (module.js:504:12)
    at Function.Module._load (module.js:496:3)
    at loadApplicationPackage (/home/choco/Repos/CrystalChocolate/node_modules/electron/dist/resources/default_app.asar/main.js:287:12)
    at Object.<anonymous> (/home/choco/Repos/CrystalChocolate/node_modules/electron/dist/resources/default_app.asar/main.js:328:5)
    at Object.<anonymous> (/home/choco/Repos/CrystalChocolate/node_modules/electron/dist/resources/default_app.asar/main.js:365:3)
    at Module._compile (module.js:642:30)
    at Object.Module._extensions..js (module.js:653:10)
    at Module.load (module.js:561:32)
    at tryModuleLoad (module.js:504:12)
    at Function.Module._load (module.js:496:3)

```